### PR TITLE
datahub: add w-max class in tailwind safelist

### DIFF
--- a/apps/datahub/tailwind.config.js
+++ b/apps/datahub/tailwind.config.js
@@ -4,6 +4,7 @@ const { join } = require('path')
 
 module.exports = {
   ...baseConfig,
+  safelist: [...baseConfig.safelist, 'w-max'],
   theme: {
     ...baseConfig.theme,
     extend: {

--- a/tailwind.base.config.js
+++ b/tailwind.base.config.js
@@ -1,4 +1,5 @@
 module.exports = {
+  safelist: [],
   theme: {
     extend: {
       colors: {


### PR DESCRIPTION
Classes that are used in the configuration file are not kept in the Tailwind output.
I think it's reasonable to add some classes (eg `w-max`) in the safelist which could be used in the datahub header title.

I would push the 2 commits upstream.