### PR TITLE
GSGCT-50 : Link not showing correctly in the dataset view

### DIFF
--- a/libs/feature/search/src/lib/utils/mapper/elasticsearch.field.mapper.ts
+++ b/libs/feature/search/src/lib/utils/mapper/elasticsearch.field.mapper.ts
@@ -199,15 +199,17 @@ export class ElasticsearchFieldMapper {
   }
 
   mapLink(sourceLink: SourceWithUnknownProps): MetadataLink | null {
-    const url = getAsUrl(selectField<string>(sourceLink, 'url'))
+    const url = sourceLink.urlObject['default'] as string
+    console.log(url)
     // no url: fail early
     if (url === null) {
       // TODO: collect errors at the record level?
+      console.log(sourceLink)
       console.warn('A link without valid URL was found', sourceLink)
       return null
     }
 
-    const protocolMatch = /^(https?|ftp):/.test(url)
+    const protocolMatch = /^(https?|ftp):/.test(url as string)
     if (!protocolMatch) {
       // TODO: collect errors at the record level?
       console.warn(
@@ -217,8 +219,8 @@ export class ElasticsearchFieldMapper {
       return null
     }
 
-    const name = selectField<string>(sourceLink, 'name')
-    const description = selectField<string>(sourceLink, 'description')
+    const name = sourceLink.nameObject['default']
+    const description = sourceLink.descriptionObject['default']
     const label = description || name
     const protocol = selectField<string>(sourceLink, 'protocol')
 
@@ -226,7 +228,7 @@ export class ElasticsearchFieldMapper {
       protocol && protocol.match(/^WWW:DOWNLOAD:(.+\/.+)$/)
     const mimeType = mimeTypeMatches && mimeTypeMatches[1]
 
-    const type = this.getLinkType(url, protocol)
+    const type = this.getLinkType(url as string, protocol)
 
     return {
       url,

--- a/libs/feature/search/src/lib/utils/mapper/elasticsearch.field.mapper.ts
+++ b/libs/feature/search/src/lib/utils/mapper/elasticsearch.field.mapper.ts
@@ -238,7 +238,7 @@ export class ElasticsearchFieldMapper {
       protocol && protocol.match(/^WWW:DOWNLOAD:(.+\/.+)$/)
     const mimeType = mimeTypeMatches && mimeTypeMatches[1]
 
-    const type = this.getLinkType(url as string, protocol)
+    const type = this.getLinkType(url.toString(), protocol)
 
     return {
       url,

--- a/libs/feature/search/src/lib/utils/mapper/elasticsearch.field.mapper.ts
+++ b/libs/feature/search/src/lib/utils/mapper/elasticsearch.field.mapper.ts
@@ -199,7 +199,18 @@ export class ElasticsearchFieldMapper {
   }
 
   mapLink(sourceLink: SourceWithUnknownProps): MetadataLink | null {
-    const url = sourceLink.urlObject['default'] as string
+    let url
+    let name
+    let description
+    if (sourceLink.urlObject) {
+      url = sourceLink.urlObject['default'] as string
+      name = sourceLink.nameObject['default']
+      description = sourceLink.descriptionObject['default']
+    } else {
+      url = getAsUrl(selectField<string>(sourceLink, 'url'))
+      name = selectField<string>(sourceLink, 'name')
+      description = selectField<string>(sourceLink, 'description')
+    }
     // no url: fail early
     if (url === null) {
       // TODO: collect errors at the record level?
@@ -217,8 +228,6 @@ export class ElasticsearchFieldMapper {
       return null
     }
 
-    const name = sourceLink.nameObject['default']
-    const description = sourceLink.descriptionObject['default']
     const label = description || name
     const protocol = selectField<string>(sourceLink, 'protocol')
 

--- a/libs/feature/search/src/lib/utils/mapper/elasticsearch.field.mapper.ts
+++ b/libs/feature/search/src/lib/utils/mapper/elasticsearch.field.mapper.ts
@@ -200,11 +200,9 @@ export class ElasticsearchFieldMapper {
 
   mapLink(sourceLink: SourceWithUnknownProps): MetadataLink | null {
     const url = sourceLink.urlObject['default'] as string
-    console.log(url)
     // no url: fail early
     if (url === null) {
       // TODO: collect errors at the record level?
-      console.log(sourceLink)
       console.warn('A link without valid URL was found', sourceLink)
       return null
     }

--- a/libs/feature/search/src/lib/utils/mapper/elasticsearch.field.mapper.ts
+++ b/libs/feature/search/src/lib/utils/mapper/elasticsearch.field.mapper.ts
@@ -199,18 +199,21 @@ export class ElasticsearchFieldMapper {
   }
 
   mapLink(sourceLink: SourceWithUnknownProps): MetadataLink | null {
-    let url
-    let name
-    let description
-    if (sourceLink.urlObject) {
-      url = sourceLink.urlObject['default'] as string
-      name = sourceLink.nameObject['default']
-      description = sourceLink.descriptionObject['default']
-    } else {
-      url = getAsUrl(selectField<string>(sourceLink, 'url'))
-      name = selectField<string>(sourceLink, 'name')
-      description = selectField<string>(sourceLink, 'description')
-    }
+    const url = getAsUrl(
+      selectFallback(
+        selectTranslatedField<string>(sourceLink, 'urlObject'),
+        selectField<string>(sourceLink, 'url')
+      )
+    )
+    const name = selectFallback(
+      selectTranslatedField<string>(sourceLink, 'nameObject'),
+      selectField<string>(sourceLink, 'name')
+    )
+    const description = selectFallback(
+      selectTranslatedField<string>(sourceLink, 'descriptionObject'),
+      selectField<string>(sourceLink, 'description')
+    )
+
     // no url: fail early
     if (url === null) {
       // TODO: collect errors at the record level?
@@ -218,7 +221,7 @@ export class ElasticsearchFieldMapper {
       return null
     }
 
-    const protocolMatch = /^(https?|ftp):/.test(url as string)
+    const protocolMatch = /^(https?|ftp):/.test(url)
     if (!protocolMatch) {
       // TODO: collect errors at the record level?
       console.warn(

--- a/libs/feature/search/src/lib/utils/mapper/elasticsearch.mapper.spec.ts
+++ b/libs/feature/search/src/lib/utils/mapper/elasticsearch.mapper.spec.ts
@@ -150,15 +150,13 @@ describe('ElasticsearchMapper', () => {
             hit._source.link = [
               {
                 protocol: 'MY-PROTOCOL',
-                nameObject: { default: 'my data layer' },
-                urlObject: { default: 'https://my.website/services/data/' },
-                descriptionObject: { default: '' },
+                name: 'my data layer',
+                url: 'https://my.website/services/data/',
               },
             ]
           })
           it('parses as a valid link, uses name as label', async () => {
             const summary = await firstValueFrom(service.toRecord(hit))
-            console.log(summary.links)
             expect(summary.links).toEqual([
               {
                 protocol: 'MY-PROTOCOL',
@@ -174,11 +172,8 @@ describe('ElasticsearchMapper', () => {
           beforeEach(() => {
             hit._source.link = [
               {
-                urlObject: {
-                  default: 'https://my.website/services/static/data.csv',
-                },
-                descriptionObject: { default: 'Download this file!' },
-                nameObject: { default: '' },
+                description: 'Download this file!',
+                url: 'https://my.website/services/static/data.csv',
               },
             ]
           })
@@ -198,12 +193,9 @@ describe('ElasticsearchMapper', () => {
           beforeEach(() => {
             hit._source.link = [
               {
-                descriptionObject: { default: 'Download this file!' },
+                description: 'Download this file!',
                 protocol: 'WWW:DOWNLOAD:application/csv',
-                urlObject: {
-                  default: 'https://my.website/services/static/data.csv',
-                },
-                nameObject: { default: '' },
+                url: 'https://my.website/services/static/data.csv',
               },
             ]
           })
@@ -226,9 +218,7 @@ describe('ElasticsearchMapper', () => {
             hit._source.link = [
               {
                 protocol: 'MY-PROTOCOL',
-                urlObject: { default: 'httpsabcd:1234:5678/@' },
-                nameObject: { default: '' },
-                descriptionObject: { default: '' },
+                url: 'https://abcd:1234:5678/@',
               },
             ]
           })
@@ -245,10 +235,9 @@ describe('ElasticsearchMapper', () => {
           beforeEach(() => {
             hit._source.link = [
               {
-                descriptionObject: { default: 'Download this file!' },
+                description: 'Download this file!',
                 protocol: 'FILE',
-                urlObject: { default: 'data:image/png;base64,aaaaabbbbbccccc' },
-                nameObject: { default: '' },
+                url: 'data:image/png;base64,aaaaabbbbbccccc',
               },
             ]
           })
@@ -259,6 +248,63 @@ describe('ElasticsearchMapper', () => {
               expect.stringContaining('protocol'),
               expect.any(Object)
             )
+          })
+        })
+        describe('link is multilingual (+ name / description)', () => {
+          beforeEach(() => {
+            hit._source.link = [
+              {
+                descriptionObject: {
+                  default: 'Download this file!',
+                  langfre: 'Téléchargez ce fichier!',
+                },
+                nameObject: {
+                  default: 'My file',
+                  langfre: 'Mon fichier',
+                },
+                protocol: 'MY-PROTOCOL',
+                urlObject: {
+                  default: 'https://my.website/services/static/data.csv',
+                  langfre: 'https://my.website/services/static/data.csv',
+                },
+              },
+            ]
+          })
+          it('parse the link correctly', async () => {
+            const summary = await firstValueFrom(service.toRecord(hit))
+            expect(summary.links).toEqual([
+              {
+                protocol: 'MY-PROTOCOL',
+                name: 'My file',
+                label: 'Download this file!',
+                description: 'Download this file!',
+                url: 'https://my.website/services/static/data.csv',
+                type: MetadataLinkType.OTHER,
+              },
+            ])
+          })
+        })
+        describe('link is multilingual (no name and description)', () => {
+          beforeEach(() => {
+            hit._source.link = [
+              {
+                protocol: 'MY-PROTOCOL',
+                urlObject: {
+                  default: 'https://my.website/services/static/data.csv',
+                  langfre: 'https://my.website/services/static/data.csv',
+                },
+              },
+            ]
+          })
+          it('parse the link correctly', async () => {
+            const summary = await firstValueFrom(service.toRecord(hit))
+            expect(summary.links).toEqual([
+              {
+                protocol: 'MY-PROTOCOL',
+                url: 'https://my.website/services/static/data.csv',
+                type: MetadataLinkType.OTHER,
+              },
+            ])
           })
         })
       })
@@ -281,10 +327,8 @@ describe('ElasticsearchMapper', () => {
             hit._source.link = [
               {
                 protocol: 'MYPROTOCOL',
-                urlObject: { default: 'https://abcd/' },
+                url: 'https://abcd/',
                 type: MetadataLinkType.OTHER,
-                descriptionObject: { default: '' },
-                nameObject: { default: '' },
               },
             ]
             summary = await firstValueFrom(service.toRecord(hit))
@@ -301,19 +345,13 @@ describe('ElasticsearchMapper', () => {
             hit._source.link = [
               {
                 protocol: 'OGC:WMS',
-                urlObject: { default: 'https://my.ogc.server/wms' },
+                url: 'https://my.ogc.server/wms',
                 type: MetadataLinkType.WMS,
-                descriptionObject: { default: '' },
-                nameObject: { default: '' },
               },
               {
                 protocol: 'WWW:DOWNLOAD',
-                urlObject: {
-                  default: 'http://my.server/files/geographic/dataset.gpkg',
-                },
+                url: 'http://my.server/files/geographic/dataset.gpkg',
                 type: MetadataLinkType.DOWNLOAD,
-                descriptionObject: { default: '' },
-                nameObject: { default: '' },
               },
             ]
             summary = await firstValueFrom(service.toRecord(hit))

--- a/libs/feature/search/src/lib/utils/mapper/elasticsearch.mapper.spec.ts
+++ b/libs/feature/search/src/lib/utils/mapper/elasticsearch.mapper.spec.ts
@@ -150,13 +150,15 @@ describe('ElasticsearchMapper', () => {
             hit._source.link = [
               {
                 protocol: 'MY-PROTOCOL',
-                name: 'my data layer',
-                url: 'https://my.website/services/data/',
+                nameObject: { default: 'my data layer' },
+                urlObject: { default: 'https://my.website/services/data/' },
+                descriptionObject: { default: '' },
               },
             ]
           })
           it('parses as a valid link, uses name as label', async () => {
             const summary = await firstValueFrom(service.toRecord(hit))
+            console.log(summary.links)
             expect(summary.links).toEqual([
               {
                 protocol: 'MY-PROTOCOL',
@@ -172,8 +174,11 @@ describe('ElasticsearchMapper', () => {
           beforeEach(() => {
             hit._source.link = [
               {
-                description: 'Download this file!',
-                url: 'https://my.website/services/static/data.csv',
+                urlObject: {
+                  default: 'https://my.website/services/static/data.csv',
+                },
+                descriptionObject: { default: 'Download this file!' },
+                nameObject: { default: '' },
               },
             ]
           })
@@ -193,9 +198,12 @@ describe('ElasticsearchMapper', () => {
           beforeEach(() => {
             hit._source.link = [
               {
-                description: 'Download this file!',
+                descriptionObject: { default: 'Download this file!' },
                 protocol: 'WWW:DOWNLOAD:application/csv',
-                url: 'https://my.website/services/static/data.csv',
+                urlObject: {
+                  default: 'https://my.website/services/static/data.csv',
+                },
+                nameObject: { default: '' },
               },
             ]
           })
@@ -218,7 +226,9 @@ describe('ElasticsearchMapper', () => {
             hit._source.link = [
               {
                 protocol: 'MY-PROTOCOL',
-                url: 'https://abcd:1234:5678/@',
+                urlObject: { default: 'httpsabcd:1234:5678/@' },
+                nameObject: { default: '' },
+                descriptionObject: { default: '' },
               },
             ]
           })
@@ -235,9 +245,10 @@ describe('ElasticsearchMapper', () => {
           beforeEach(() => {
             hit._source.link = [
               {
-                description: 'Download this file!',
+                descriptionObject: { default: 'Download this file!' },
                 protocol: 'FILE',
-                url: 'data:image/png;base64,aaaaabbbbbccccc',
+                urlObject: { default: 'data:image/png;base64,aaaaabbbbbccccc' },
+                nameObject: { default: '' },
               },
             ]
           })
@@ -270,8 +281,10 @@ describe('ElasticsearchMapper', () => {
             hit._source.link = [
               {
                 protocol: 'MYPROTOCOL',
-                url: 'https://abcd/',
+                urlObject: { default: 'https://abcd/' },
                 type: MetadataLinkType.OTHER,
+                descriptionObject: { default: '' },
+                nameObject: { default: '' },
               },
             ]
             summary = await firstValueFrom(service.toRecord(hit))
@@ -288,13 +301,19 @@ describe('ElasticsearchMapper', () => {
             hit._source.link = [
               {
                 protocol: 'OGC:WMS',
-                url: 'https://my.ogc.server/wms',
+                urlObject: { default: 'https://my.ogc.server/wms' },
                 type: MetadataLinkType.WMS,
+                descriptionObject: { default: '' },
+                nameObject: { default: '' },
               },
               {
                 protocol: 'WWW:DOWNLOAD',
-                url: 'http://my.server/files/geographic/dataset.gpkg',
+                urlObject: {
+                  default: 'http://my.server/files/geographic/dataset.gpkg',
+                },
                 type: MetadataLinkType.DOWNLOAD,
+                descriptionObject: { default: '' },
+                nameObject: { default: '' },
               },
             ]
             summary = await firstValueFrom(service.toRecord(hit))


### PR DESCRIPTION
### JIRA Ticket

https://jira.camptocamp.com/browse/GSGCT-50

### Issue

In dataset view, the links were available but without any title displayed. Moreover, the links led to dead or empty pages.

### Resolution

The mapping of elastic search was trying to get attributes that didn't exist for the links, titles and descriptions. Corrected this and all links should now work.

### To test

Go to `/dataset/3b7e60ed-6f0f-40c6-b720-2add47af2f7d` (reported dataset - many datasets do not have links so it's a good one to test on).