### PR TITLE
GSGCT-56 : Rename the "sort by date" label

### DIFF
--- a/translations/fr.json
+++ b/translations/fr.json
@@ -187,7 +187,7 @@
   "results.records.hits.empty.help.html": "Suggestions : <ul class='list-disc list-inside'><li>Essayez d'autres mots clés</li><li>Cherchez moins de mots</li></ul>",
   "results.records.hits.found": "{hits, plural, =0{Aucune correspondance.} one{1 enregistrement trouvé.} other{{hits} résultats.}}",
   "results.showMore": "Plus de résultats...",
-  "results.sortBy.dateStamp": "Date",
+  "results.sortBy.dateStamp": "Plus récent",
   "results.sortBy.popularity": "Popularité",
   "results.sortBy.relevancy": "Pertinence",
   "search.autocomplete.error": "Les suggestions ne peuvent pas être récupérées",


### PR DESCRIPTION
### JIRA Ticket

https://jira.camptocamp.com/browse/GSGCT-56

### Issue

The 'Filter' dropdown in the dataset page was unclear about the "Date" criteria.

### Resolution

Changed the French translation for `results.sortBy.dateStamp` variable.

### To test

Go to dataset page, and look up the "Filter" dropdown.