### PR TITLE
chore(DH): Change link to original metadata

### DIFF
--- a/libs/ui/elements/src/lib/metadata-info/metadata-info.component.html
+++ b/libs/ui/elements/src/lib/metadata-info/metadata-info.component.html
@@ -200,8 +200,10 @@
     <div *ngIf="metadata.landingPage">
       <p class="text-sm" translate>record.metadata.sheet</p>
       <p class="text-primary font-medium" translate>
-        <a [href]="metadata.landingPage" target="_blank">
-          <span class="break-all" gnUiLinkify>{{ metadata.landingPage }}</span>
+        <a [href]="metadataLandingPageAdvanced" target="_blank">
+          <span class="break-all" gnUiLinkify>{{
+            metadataLandingPageAdvanced
+          }}</span>
         </a>
       </p>
     </div>

--- a/libs/ui/elements/src/lib/metadata-info/metadata-info.component.ts
+++ b/libs/ui/elements/src/lib/metadata-info/metadata-info.component.ts
@@ -90,6 +90,12 @@ export class MetadataInfoComponent {
     return this.metadata.contactsForResource?.[0]
   }
 
+  get metadataLandingPageAdvanced() {
+    return (
+      this.metadata.landingPage + `/formatters/xsl-view?root=div&view=advanced`
+    )
+  }
+
   fieldReady(propName: string) {
     return !this.incomplete || propName in this.metadata
   }

--- a/libs/ui/elements/src/lib/metadata-info/metadata-info.component.ts
+++ b/libs/ui/elements/src/lib/metadata-info/metadata-info.component.ts
@@ -90,6 +90,7 @@ export class MetadataInfoComponent {
     return this.metadata.contactsForResource?.[0]
   }
 
+  // geocat specific
   get metadataLandingPageAdvanced() {
     return (
       this.metadata.landingPage + `/formatters/xsl-view?root=div&view=advanced`

--- a/translations/de.json
+++ b/translations/de.json
@@ -256,7 +256,7 @@
   "record.metadata.quality.updateFrequency.failed": "Aktualisierungsfrequenz nicht angegeben",
   "record.metadata.quality.updateFrequency.success": "Aktualisierungsfrequenz angegeben",
   "record.metadata.related": "Ähnliche Datensätze",
-  "record.metadata.sheet": "Weitere Informationen verfügbar unter:",
+  "record.metadata.sheet": "Weitere detaillierte Informationen verfügbar unter:",
   "record.metadata.status": "Status",
   "record.metadata.technical": "Technische Informationen",
   "record.metadata.temporalExtent": "Zeitlicher Umfang",

--- a/translations/en.json
+++ b/translations/en.json
@@ -256,7 +256,7 @@
   "record.metadata.quality.updateFrequency.failed": "Update frequency is not specified",
   "record.metadata.quality.updateFrequency.success": "Update frequency is specified",
   "record.metadata.related": "Related records",
-  "record.metadata.sheet": "Original metadata",
+  "record.metadata.sheet": "Detailed original metadata",
   "record.metadata.status": "Status",
   "record.metadata.technical": "Technical information",
   "record.metadata.temporalExtent": "Temporal extent",

--- a/translations/fr.json
+++ b/translations/fr.json
@@ -256,7 +256,7 @@
   "record.metadata.quality.updateFrequency.failed": "Fréquence de mise à jour n'est pas renseignée",
   "record.metadata.quality.updateFrequency.success": "Fréquence de mise à jour est renseignée",
   "record.metadata.related": "Voir aussi",
-  "record.metadata.sheet": "Fiche de métadonnées d'origine",
+  "record.metadata.sheet": "Fiche de métadonnées détaillée d'origine",
   "record.metadata.status": "Statut",
   "record.metadata.technical": "Informations techniques",
   "record.metadata.temporalExtent": "Etendue temporelle",


### PR DESCRIPTION
### Description

This PR introduces a change of the link inside of the metadata info that refers to the resource in geonetwork.
It also changes the translation for its label. 

### Screenshots

![image](https://github.com/camptocamp/geocat-geonetwork-ui/assets/133115263/a78ad155-2fc4-4465-b65a-d62043d92743)


### Quality Assurance Checklist

- [ ] Commit history is devoid of any _merge commits_ and readable to facilitate reviews
- [ ] If **new logic** ⚙️ is introduced: unit tests were added
- [ ] If **new user stories** 🤏 are introduced: E2E tests were added
- [ ] If **new UI components** 🕹️ are introduced: corresponding stories in Storybook were created
- [ ] If **breaking changes** 🪚 are introduced: add the `breaking change` label
- [ ] If **bugs** 🐞 are fixed: add the `backport <release branch>` label
- [ ] The [documentation website](docs) 📚 has received the love it deserves
