### PR TITLE
Add another link to geonetwork in the navigation bar

### DIFF
--- a/apps/datahub/src/app/home/geocat-header/geocat-header.component.html
+++ b/apps/datahub/src/app/home/geocat-header/geocat-header.component.html
@@ -2,10 +2,16 @@
   <div
     class="mx-auto flex items-center justify-center sm:justify-end gap-2 py-1 text-sm"
   >
+    <a
+      class="block hover:underline mr-4"
+      [href]="gnLinkGeneral"
+      target="_blank"
+      >{{ 'datahub.header.geonetwork' | translate }}</a
+    >
     <a class="block hover:underline mr-4" [href]="docLink" target="_blank">{{
       'datahub.header.documentation' | translate
     }}</a>
-    <a class="block hover:underline" [href]="gnLink" target="_blank">{{
+    <a class="block hover:underline" [href]="gnLinkAdmin" target="_blank">{{
       'datahub.header.admin' | translate
     }}</a>
     <gn-ui-language-switcher

--- a/apps/datahub/src/app/home/geocat-header/geocat-header.component.ts
+++ b/apps/datahub/src/app/home/geocat-header/geocat-header.component.ts
@@ -18,9 +18,15 @@ export class GeocatHeaderComponent {
     }/home.html`
   }
 
-  get gnLink() {
+  get gnLinkAdmin() {
     return `/geonetwork/srv/${
       LANG_2_TO_3_MAPPER[this.translate.currentLang] || 'eng'
     }/catalog.edit#/board`
+  }
+
+  get gnLinkGeneral() {
+    return `/geonetwork/srv/${
+      LANG_2_TO_3_MAPPER[this.translate.currentLang] || 'eng'
+    }/catalog.search#/home`
   }
 }


### PR DESCRIPTION
### Description
This PR adds a link that points to geonetwork to the top navigation bar

NOTE:
The translation have still to be added in the configuration, the key for this is `datahub.header.geonetwork`.
The link should say: "Geocat PRO"

### Screenshots
![image](https://github.com/camptocamp/geocat-geonetwork-ui/assets/133115263/5ba86d0e-a075-46b1-a9d5-66983afedc4f)

