### PR TITLE
fix: Change url to documentation in header

### DIFF
--- a/apps/datahub/src/app/home/geocat-header/geocat-header.component.ts
+++ b/apps/datahub/src/app/home/geocat-header/geocat-header.component.ts
@@ -13,9 +13,7 @@ export class GeocatHeaderComponent {
   constructor(private translate: TranslateService) {}
 
   get docLink() {
-    return `https://www.geocat.admin.ch/${
-      this.translate.currentLang || 'en'
-    }/home.html`
+    return `https://www.info.geocat.ch`
   }
 
   get gnLinkAdmin() {


### PR DESCRIPTION
### Description

This PR introduces a change to the url for the documentation in the header. Now the url should point to: `https://www.info.geocat.ch/`
