### PR TITLE
Change title of app to geocat.ch

### DIFF
--- a/apps/datahub/src/index.html
+++ b/apps/datahub/src/index.html
@@ -2,7 +2,7 @@
 <html lang="en" class="overflow-y-scroll">
   <head>
     <meta charset="utf-8" />
-    <title>Datahub</title>
+    <title>geocat.ch</title>
     <base href="/" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />


### PR DESCRIPTION
### Description

This PR introduces a change in the application `<title>` from "Datahub" to "geocat.ch"
