### PR TITLE
[Webcomponents]: Fix bug where gn-record-view stays empty

### DIFF
--- a/apps/webcomponents/src/app/components/gn-record-view/gn-record-view.component.html
+++ b/apps/webcomponents/src/app/components/gn-record-view/gn-record-view.component.html
@@ -19,7 +19,9 @@
     <gn-ui-metadata-contact [metadata]="record"></gn-ui-metadata-contact>
 
     <div *ngIf="getDownloads(record?.onlineResources)?.length > 0">
-      <div class="font-title text-lg mt-4 mb-2 flex flex-row gap-4 items-center">
+      <div
+        class="font-title text-lg mt-4 mb-2 flex flex-row gap-4 items-center"
+      >
         <span translate>record.metadata.download</span>
         <gn-ui-previous-next-buttons
           *ngIf="downloads?.pagesCount > 1"
@@ -39,7 +41,9 @@
     </div>
 
     <div *ngIf="getLinks(record?.onlineResources)?.length > 0">
-      <div class="font-title text-lg mt-4 mb-2 flex flex-row gap-4 items-center">
+      <div
+        class="font-title text-lg mt-4 mb-2 flex flex-row gap-4 items-center"
+      >
         <span translate>record.metadata.links</span>
         <gn-ui-previous-next-buttons
           *ngIf="links?.pagesCount > 1"
@@ -56,7 +60,9 @@
     </div>
 
     <div *ngIf="getAPIs(record?.onlineResources)?.length > 0">
-      <div class="font-title text-lg mt-4 mb-2 flex flex-row gap-4 items-center">
+      <div
+        class="font-title text-lg mt-4 mb-2 flex flex-row gap-4 items-center"
+      >
         <span translate>record.metadata.api</span>
         <gn-ui-previous-next-buttons
           *ngIf="apis?.pagesCount > 1"
@@ -67,6 +73,7 @@
         <gn-ui-api-card
           *ngFor="let otherLink of getAPIs(record?.onlineResources)"
           [link]="otherLink"
+          [currentLink]="otherLink"
         ></gn-ui-api-card>
       </gn-ui-block-list>
     </div>

--- a/apps/webcomponents/src/app/components/gn-record-view/gn-record-view.component.ts
+++ b/apps/webcomponents/src/app/components/gn-record-view/gn-record-view.component.ts
@@ -26,42 +26,41 @@ import {
   encapsulation: ViewEncapsulation.ShadowDom,
   providers: [SearchFacade],
 })
-
 export class GnRecordViewComponent extends BaseComponent implements OnInit {
-  @Input() recordId!: string;
-  record$: Observable<CatalogRecord | null>;
-  downloads$: Observable<OnlineResource[]>;
-  links$: Observable<OnlineResource[]>;
-  apis$: Observable<OnlineResource[]>;
+  @Input() recordId!: string
+  record$: Observable<CatalogRecord | null>
+  downloads$: Observable<OnlineResource[]>
+  links$: Observable<OnlineResource[]>
+  apis$: Observable<OnlineResource[]>
 
   constructor(injector: Injector) {
-    super(injector);
+    super(injector)
   }
 
   ngOnInit() {
-    super.ngOnInit();
-    this.record$ = this.recordsRepository.getRecord(this.recordId);
+    super.ngOnInit()
+    this.record$ = this.recordsRepository.getRecord(this.recordId)
 
     this.downloads$ = this.record$.pipe(
       map((record) => this.getDownloads(record?.onlineResources || []))
-    );
+    )
     this.links$ = this.record$.pipe(
       map((record) => this.getLinks(record?.onlineResources || []))
-    );
+    )
     this.apis$ = this.record$.pipe(
       map((record) => this.getAPIs(record?.onlineResources || []))
-    );
+    )
   }
 
   getDownloads(onlineResources: OnlineResource[]): OnlineResource[] {
-    return onlineResources.filter((resource) => resource.type === 'download');
+    return onlineResources.filter((resource) => resource.type === 'download')
   }
 
   getLinks(onlineResources: OnlineResource[]): OnlineResource[] {
-    return onlineResources.filter((resource) => resource.type === 'link');
+    return onlineResources.filter((resource) => resource.type === 'link')
   }
 
   getAPIs(onlineResources: OnlineResource[]): OnlineResource[] {
-    return onlineResources.filter((resource) => resource.type === 'service');
+    return onlineResources.filter((resource) => resource.type === 'service')
   }
 }


### PR DESCRIPTION
### Description

This PR fixes the bug where the gn-record-view stays empty in some cases. This was due to `gn-ui-api-card` needing the input "currentLink" in addition of "link", which was the only one passed down.

### Quality Assurance Checklist

- [ ] Commit history is devoid of any _merge commits_ and readable to facilitate reviews
- [ ] If **new logic** ⚙️ is introduced: unit tests were added
- [ ] If **new user stories** 🤏 are introduced: E2E tests were added
- [ ] If **new UI components** 🕹️ are introduced: corresponding stories in Storybook were created
- [ ] If **breaking changes** 🪚 are introduced: add the `breaking change` label
- [ ] If **bugs** 🐞 are fixed: add the `backport <release branch>` label
- [ ] The [documentation website](docs) 📚 has received the love it deserves